### PR TITLE
Document how to install via Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,22 @@ ql <path/to/file>
 
 Yes, there is `qlmanage`. But you’d always have `[DEBUG]` staring at you.
 
+## Installing 📦
+
+You can install `ql` via Homebrew:
+
+```shell
+brew install --HEAD pmeinhardt/tools/ql
+```
+
+This will build the tool from source.
+
+To update, use:
+
+```shell
+brew upgrade --fetch-HEAD pmeinhardt/tools/ql
+```
+
 ## Building 🪛
 
 In order to build the `ql` command, run:


### PR DESCRIPTION
I've added a Homebrew formula in my Homebrew tap which builds `ql` from source:
https://github.com/pmeinhardt/homebrew-tools/blob/main/Formula/ql.rb

Maybe not quite as convenient as downloading a pre-built universal binary,
but hopefully a little more convenient (for Homebrew users) than following the build steps yourself.

Closes #2.
